### PR TITLE
Match multiple fixes in a commit

### DIFF
--- a/release-notes-generator.ts
+++ b/release-notes-generator.ts
@@ -16,7 +16,7 @@ type ClubhouseBulkUpdateStories = {
 }
 
 export class ReleaseNotesGenerator {
-	private issueRegex = /\b(?:fixes|fix|closes|closed|finish|finishes)\b (?:\[?)ch(?:-?)(\d+)(?:\]?)/i;
+	private issueRegex = /\b(?:fixes|fix|closes|closed|finish|finishes)\b (?:\[?)ch(?:-?)(\d+)(?:\]?)/gi;
 	private prRegex = /pull request \#(\d+)/i;
 
 	constructor(


### PR DESCRIPTION
Fixes [ch-2031]

matchAll is supposed to throw an error when regex isnt global: https://tc39.es/ecma262/#sec-string.prototype.matchall
node however allows this and only returns the first result